### PR TITLE
Potential fix for code scanning alert no. 65: Local information disclosure in a temporary directory

### DIFF
--- a/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/util/Streams.java
+++ b/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/util/Streams.java
@@ -1,7 +1,13 @@
 package com.payneteasy.dcagent.core.util;
 
 import java.io.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 public class Streams {
@@ -28,7 +34,19 @@ public class Streams {
     public static File writeToTempFile(InputStream aInputStream, String aPrefix, String aSuffix) {
         File tempFile;
         try {
-            tempFile = File.createTempFile(aPrefix, aSuffix);
+            Path tempPath;
+            if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+                tempPath = Files.createTempFile(
+                        aPrefix,
+                        aSuffix,
+                        PosixFilePermissions.asFileAttribute(
+                                EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+                        )
+                );
+            } else {
+                tempPath = Files.createTempFile(aPrefix, aSuffix);
+            }
+            tempFile = tempPath.toFile();
         } catch (IOException e) {
             throw new IllegalStateException("Cannot create temp file", e);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/evsinev/dc-agent/security/code-scanning/65](https://github.com/evsinev/dc-agent/security/code-scanning/65)

Use `java.nio.file.Files.createTempFile(...)` and, on POSIX file systems, explicitly set owner-only permissions at creation time (`rw-------`). Keep behavior the same (still return `File`, still same error handling) by converting `Path` back to `File`.

Best fix in this file:
- In `dc-agent-core/src/main/java/com/payneteasy/dcagent/core/util/Streams.java`, update `writeToTempFile(...)` around line 31.
- Replace `File.createTempFile(...)` with:
  - POSIX branch: `Files.createTempFile(prefix, suffix, PosixFilePermissions.asFileAttribute(...))`
  - Non-POSIX branch (e.g., Windows): `Files.createTempFile(prefix, suffix)`
- Convert created `Path` to `File` with `toFile()`.
- Add required imports for `java.nio.file.*`, `java.nio.file.attribute.*`, and `java.util.EnumSet`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
