### PR TITLE
Potential fix for code scanning alert no. 64: Local information disclosure in a temporary directory

### DIFF
--- a/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/modules/zipachive/TempFile.java
+++ b/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/modules/zipachive/TempFile.java
@@ -5,6 +5,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
 
 import static com.payneteasy.dcagent.core.util.Strings.forLog;
 import static com.payneteasy.dcagent.core.util.Strings.hasText;
@@ -21,7 +25,22 @@ public class TempFile implements Closeable {
 
     public TempFile(String aName, String aExtension) {
         try {
-            file = File.createTempFile(aName + "-" + System.currentTimeMillis(), "." + aExtension);
+            Path tempPath;
+            if (java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+                tempPath = Files.createTempFile(
+                        aName + "-" + System.currentTimeMillis(),
+                        "." + aExtension,
+                        PosixFilePermissions.asFileAttribute(
+                                EnumSet.of(
+                                        PosixFilePermission.OWNER_READ,
+                                        PosixFilePermission.OWNER_WRITE
+                                )
+                        )
+                );
+            } else {
+                tempPath = Files.createTempFile(aName + "-" + System.currentTimeMillis(), "." + aExtension);
+            }
+            file = tempPath.toFile();
             LOG.debug("Created temp file {}", forLog(file.getAbsolutePath()));
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot create temp file", e);


### PR DESCRIPTION
Potential fix for [https://github.com/evsinev/dc-agent/security/code-scanning/64](https://github.com/evsinev/dc-agent/security/code-scanning/64)

Use `java.nio.file.Files.createTempFile(...)` instead of `File.createTempFile(...)`, and on POSIX-capable file systems explicitly set owner-only permissions at creation time (`rw-------`). For non-POSIX systems (for example Windows), call the overload without POSIX attributes.

In `dc-agent-core/src/main/java/com/payneteasy/dcagent/core/modules/zipachive/TempFile.java`, update:
- Imports: add `java.nio.file.Path`, `java.nio.file.attribute.PosixFilePermission`, `java.nio.file.attribute.PosixFilePermissions`, and `java.util.EnumSet`.
- Constructor block around line 24: replace `File.createTempFile(...)` with `Files.createTempFile(...)` using a conditional based on `FileSystems.getDefault().supportedFileAttributeViews().contains("posix")`, then convert `Path` to `File`.
This preserves behavior (temp file creation, naming pattern, logging, existing write/delete flow) while ensuring secure permissions where needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
