### PR TITLE
feat(gc): per-pause GC diagnostics, verdict, and copy-for-LLM payload

### DIFF
--- a/dc-agent-app/src/main/java/com/payneteasy/dcagent/metrics/GcStatsCollector.java
+++ b/dc-agent-app/src/main/java/com/payneteasy/dcagent/metrics/GcStatsCollector.java
@@ -1,0 +1,123 @@
+package com.payneteasy.dcagent.metrics;
+
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.NotificationEmitter;
+import javax.management.openmbean.CompositeData;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Subscribes to {@link GarbageCollectionNotificationInfo} JMX notifications and keeps a running
+ * summary of GC behaviour: total collections, longest pause, a decaying "recent" pause figure, the
+ * last cause, and the live-set size after the most recent collection (heap used right after a GC —
+ * the closest single number to "how much memory the app actually holds").
+ *
+ * <p>Deliberately does NOT keep per-event history (that would grow unbounded and is what a log or
+ * GCToolKit is for). It keeps only the aggregates the operator needs to render a one-line verdict.
+ * All fields are updated from the (single) GC notification thread and read from request threads, so
+ * they are stored in atomics / volatiles.
+ *
+ * <p>Note: the JMX bean does NOT expose the user/sys/real CPU split from the unified GC log, so the
+ * "wall-clock &gt; cpu-time" heuristic cannot be reproduced here. The operator's verdict works from
+ * pause magnitude and live-set trend instead.
+ */
+public class GcStatsCollector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GcStatsCollector.class);
+
+    private final LongAdder  totalCollections    = new LongAdder();
+    private final LongAdder  totalPauseMs         = new LongAdder();
+    private final AtomicLong maxPauseMs           = new AtomicLong(0);
+    private final AtomicLong lastPauseMs          = new AtomicLong(-1);
+    private final AtomicLong lastGcEpochMs        = new AtomicLong(-1);
+    private final AtomicLong liveSetAfterBytes    = new AtomicLong(-1); // heap used right after last GC
+    private final AtomicLong prevLiveSetAfterBytes = new AtomicLong(-1); // one before that
+    private final AtomicLong longPauseCount       = new AtomicLong(0);  // pauses over LONG_PAUSE_MS
+
+    private volatile String  lastCause  = null;
+    private volatile String  lastAction = null;
+
+    /** A pause at/over this is "long" and gets counted separately for the verdict. */
+    private static final long LONG_PAUSE_MS = 200;
+
+    /** Install listeners on every GC MXBean. Call once at startup. */
+    public void install() {
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (bean instanceof NotificationEmitter emitter) {
+                emitter.addNotificationListener((notification, handback) -> {
+                    if (GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION
+                            .equals(notification.getType())) {
+                        onGc(GarbageCollectionNotificationInfo.from(
+                                (CompositeData) notification.getUserData()));
+                    }
+                }, null, null);
+            }
+        }
+        LOG.info("GC stats collector installed on {} collectors",
+                ManagementFactory.getGarbageCollectorMXBeans().size());
+    }
+
+    private void onGc(GarbageCollectionNotificationInfo info) {
+        try {
+            GcInfo gc      = info.getGcInfo();
+            long   pauseMs = gc.getDuration();
+
+            totalCollections.increment();
+            totalPauseMs.add(pauseMs);
+            lastPauseMs.set(pauseMs);
+            lastGcEpochMs.set(System.currentTimeMillis());
+            lastCause  = info.getGcCause();
+            lastAction = info.getGcAction();
+
+            maxPauseMs.accumulateAndGet(pauseMs, Math::max);
+            if (pauseMs >= LONG_PAUSE_MS) {
+                longPauseCount.incrementAndGet();
+            }
+
+            long usedAfter = sumUsed(gc.getMemoryUsageAfterGc());
+            prevLiveSetAfterBytes.set(liveSetAfterBytes.get());
+            liveSetAfterBytes.set(usedAfter);
+        } catch (Exception e) {
+            LOG.debug("Cannot process GC notification", e);
+        }
+    }
+
+    private static long sumUsed(Map<String, MemoryUsage> pools) {
+        long sum = 0;
+        for (MemoryUsage u : pools.values()) {
+            if (u != null && u.getUsed() > 0) {
+                sum += u.getUsed();
+            }
+        }
+        return sum;
+    }
+
+    /** Snapshot the current aggregates. Cheap; safe to call per request. */
+    public TGcInfo snapshot() {
+        long count = totalCollections.sum();
+        long total = totalPauseMs.sum();
+        return TGcInfo.builder()
+                .collectionCount(count)
+                .totalPauseMs(total)
+                .avgPauseMs(count > 0 ? (double) total / count : -1)
+                .maxPauseMs(maxPauseMs.get())
+                .lastPauseMs(lastPauseMs.get())
+                .lastGcEpochMs(lastGcEpochMs.get())
+                .longPauseCount(longPauseCount.get())
+                .longPauseThresholdMs(LONG_PAUSE_MS)
+                .liveSetAfterBytes(liveSetAfterBytes.get())
+                .prevLiveSetAfterBytes(prevLiveSetAfterBytes.get())
+                .lastCause(lastCause)
+                .lastAction(lastAction)
+                .build();
+    }
+}

--- a/dc-agent-app/src/main/java/com/payneteasy/dcagent/metrics/SystemInfoCollector.java
+++ b/dc-agent-app/src/main/java/com/payneteasy/dcagent/metrics/SystemInfoCollector.java
@@ -20,18 +20,21 @@ public class SystemInfoCollector {
     private final MemoryMXBean                               memoryBean;
     private final ThreadMXBean                               threadBean;
     private final CpuLoadSampler                             cpuLoadSampler;
+    private final GcStatsCollector                           gcStatsCollector;
 
     public SystemInfoCollector() {
-        osBean         = ManagementFactory.getOperatingSystemMXBean();
-        sunOsBean      = osBean instanceof com.sun.management.OperatingSystemMXBean sun ? sun : null;
-        memoryBean     = ManagementFactory.getMemoryMXBean();
-        threadBean     = ManagementFactory.getThreadMXBean();
-        cpuLoadSampler = new CpuLoadSampler(sunOsBean);
+        osBean           = ManagementFactory.getOperatingSystemMXBean();
+        sunOsBean        = osBean instanceof com.sun.management.OperatingSystemMXBean sun ? sun : null;
+        memoryBean       = ManagementFactory.getMemoryMXBean();
+        threadBean       = ManagementFactory.getThreadMXBean();
+        cpuLoadSampler   = new CpuLoadSampler(sunOsBean);
+        gcStatsCollector = new GcStatsCollector();
     }
 
-    /** Start the background CPU-load sampler. Call once at startup. */
+    /** Start the background CPU-load sampler and install the GC listener. Call once at startup. */
     public void start() {
         cpuLoadSampler.start(2000);
+        gcStatsCollector.install();
     }
 
     public TSystemInfo collect() {
@@ -68,6 +71,7 @@ public class SystemInfoCollector {
                 .threadCount(threadBean.getThreadCount())
                 .gcCount(gcCount)
                 .gcTimeMs(gcTime)
+                .gc(gcStatsCollector.snapshot())
                 .build();
     }
 

--- a/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/remote/agent/controlplane/model/TGcInfo.java
+++ b/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/remote/agent/controlplane/model/TGcInfo.java
@@ -1,0 +1,37 @@
+package com.payneteasy.dcagent.core.remote.agent.controlplane.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Rich GC summary read from the agent's {@link com.sun.management.GarbageCollectionNotificationInfo}
+ * listener (see GcStatsCollector in dc-agent-app). Complements the coarse {@code gcCount}/{@code
+ * gcTimeMs} already in {@link TSystemInfo}: this carries per-pause statistics and the live-set trend
+ * needed for a diagnosis, not just cumulative totals.
+ *
+ * <p>All values are raw; the operator formats and interprets them. Sentinels: -1 means "not sampled
+ * yet / unavailable" (e.g. before the first GC).
+ */
+@Data
+@FieldDefaults(makeFinal = true, level = PRIVATE)
+@Builder
+public class TGcInfo {
+
+    long   collectionCount;        // number of collections since start
+    long   totalPauseMs;           // summed pause time
+    double avgPauseMs;             // totalPauseMs / collectionCount, -1 if none
+    long   maxPauseMs;             // longest single pause seen
+    long   lastPauseMs;            // duration of the most recent pause, -1 if none yet
+    long   lastGcEpochMs;          // wall-clock of the most recent GC, -1 if none yet
+    long   longPauseCount;         // pauses at/over longPauseThresholdMs
+    long   longPauseThresholdMs;   // the "long pause" cutoff used above
+
+    long   liveSetAfterBytes;      // heap used right after the most recent GC, -1 if none yet
+    long   prevLiveSetAfterBytes;  // live set after the GC before that, -1 if n/a
+
+    String lastCause;              // e.g. "G1 Evacuation Pause", nullable
+    String lastAction;             // e.g. "end of minor GC", nullable
+}

--- a/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/remote/agent/controlplane/model/TSystemInfo.java
+++ b/dc-agent-core/src/main/java/com/payneteasy/dcagent/core/remote/agent/controlplane/model/TSystemInfo.java
@@ -39,4 +39,8 @@ public class TSystemInfo {
     int    threadCount;
     long   gcCount;
     long   gcTimeMs;
+
+    // Rich per-pause GC statistics (GarbageCollectionNotificationInfo listener). Nullable if the
+    // GC stats collector is not installed; the summed gcCount/gcTimeMs above remain the fallback.
+    TGcInfo gc;
 }

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
@@ -1,10 +1,12 @@
 package com.payneteasy.dcagent.operator.service.agent.impl;
 
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
 import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TSystemInfo;
 import com.payneteasy.dcagent.operator.service.agent.model.TAgentMetrics;
 
 import java.time.Duration;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * Maps the agent's raw {@link TSystemInfo} into {@link TAgentMetrics}: keeps the raw values (for
@@ -16,7 +18,7 @@ final class AgentMetricsMapper {
     private AgentMetricsMapper() {
     }
 
-    static TAgentMetrics toMetrics(TSystemInfo aInfo) {
+    static TAgentMetrics toMetrics(String aAgentName, TSystemInfo aInfo) {
         long physicalUsed = aInfo.getPhysicalTotalBytes() >= 0 && aInfo.getPhysicalFreeBytes() >= 0
                 ? aInfo.getPhysicalTotalBytes() - aInfo.getPhysicalFreeBytes()
                 : -1;
@@ -26,6 +28,20 @@ final class AgentMetricsMapper {
         double physicalFraction = aInfo.getPhysicalTotalBytes() > 0 && physicalUsed >= 0
                 ? (double) physicalUsed / aInfo.getPhysicalTotalBytes()
                 : -1;
+
+        // Rich per-pause GC figures. gc is nullable (agent has no GC stats collector, or metrics
+        // predate it) → fall back to the -1 / "n/a" sentinels used everywhere else here.
+        TGcInfo          gc      = aInfo.getGc();
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(aInfo);
+        String           detail  = verdict.findings().isEmpty()
+                ? verdict.summary()
+                : verdict.findings().stream().map(GcDoctor.Finding::message).collect(Collectors.joining("\n"));
+        String           payload = GcLlmPayloadBuilder.build(aAgentName, aInfo);
+
+        long   gcAvgPauseMs  = gc != null && gc.getAvgPauseMs() >= 0 ? Math.round(gc.getAvgPauseMs()) : -1;
+        long   gcMaxPauseMs  = gc != null ? gc.getMaxPauseMs() : -1;
+        long   gcLastPauseMs = gc != null ? gc.getLastPauseMs() : -1;
+        long   gcLiveSet     = gc != null ? gc.getLiveSetAfterBytes() : -1;
 
         return TAgentMetrics.builder()
                 .systemCpuLoad(aInfo.getSystemCpuLoad())
@@ -63,11 +79,30 @@ final class AgentMetricsMapper {
                 .gcCount(aInfo.getGcCount())
                 .gcTimeMs(aInfo.getGcTimeMs())
                 .gcTimeText(duration(aInfo.getGcTimeMs()))
+                .gcAvgPauseMs(gcAvgPauseMs)
+                .gcAvgPauseText(gc != null && gc.getAvgPauseMs() >= 0
+                        ? String.format(Locale.ROOT, "%.1f ms", gc.getAvgPauseMs()) : "n/a")
+                .gcMaxPauseMs(gcMaxPauseMs)
+                .gcMaxPauseText(pauseText(gcMaxPauseMs))
+                .gcLastPauseMs(gcLastPauseMs)
+                .gcLastPauseText(pauseText(gcLastPauseMs))
+                .gcLongPauseCount(gc != null ? gc.getLongPauseCount() : 0)
+                .gcLiveSetBytes(gcLiveSet)
+                .gcLiveSetText(bytes(gcLiveSet))
+                .gcLastCause(gc != null && gc.getLastCause() != null ? gc.getLastCause() : "n/a")
+                .gcHealthLevel(verdict.level().name())
+                .gcHealthSummary(verdict.summary())
+                .gcHealthDetail(detail)
+                .gcLlmPayload(payload)
                 .build();
     }
 
     private static String percent(double aFraction) {
         return aFraction < 0 ? "n/a" : Math.round(aFraction * 100) + "%";
+    }
+
+    private static String pauseText(long aMillis) {
+        return aMillis < 0 ? "n/a" : aMillis + " ms";
     }
 
     private static String bytes(long aBytes) {

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
@@ -38,7 +38,6 @@ final class AgentMetricsMapper {
                 : verdict.findings().stream().map(GcDoctor.Finding::message).collect(Collectors.joining("\n"));
         String           payload = GcLlmPayloadBuilder.build(aAgentName, aInfo);
 
-        long   gcAvgPauseMs  = gc != null && gc.getAvgPauseMs() >= 0 ? Math.round(gc.getAvgPauseMs()) : -1;
         long   gcMaxPauseMs  = gc != null ? gc.getMaxPauseMs() : -1;
         long   gcLastPauseMs = gc != null ? gc.getLastPauseMs() : -1;
         long   gcLiveSet     = gc != null ? gc.getLiveSetAfterBytes() : -1;
@@ -79,9 +78,8 @@ final class AgentMetricsMapper {
                 .gcCount(aInfo.getGcCount())
                 .gcTimeMs(aInfo.getGcTimeMs())
                 .gcTimeText(duration(aInfo.getGcTimeMs()))
-                .gcAvgPauseMs(gcAvgPauseMs)
-                .gcAvgPauseText(gc != null && gc.getAvgPauseMs() >= 0
-                        ? String.format(Locale.ROOT, "%.1f ms", gc.getAvgPauseMs()) : "n/a")
+                .gcAvgPauseMs(gcAvgPauseMs(gc))
+                .gcAvgPauseText(gcAvgPauseText(gc))
                 .gcMaxPauseMs(gcMaxPauseMs)
                 .gcMaxPauseText(pauseText(gcMaxPauseMs))
                 .gcLastPauseMs(gcLastPauseMs)
@@ -89,7 +87,7 @@ final class AgentMetricsMapper {
                 .gcLongPauseCount(gc != null ? gc.getLongPauseCount() : 0)
                 .gcLiveSetBytes(gcLiveSet)
                 .gcLiveSetText(MetricFormat.bytes(gcLiveSet))
-                .gcLastCause(gc != null && gc.getLastCause() != null ? gc.getLastCause() : "n/a")
+                .gcLastCause(gcLastCause(gc))
                 .gcHealthLevel(verdict.level().name())
                 .gcHealthSummary(verdict.summary())
                 .gcHealthDetail(detail)
@@ -103,6 +101,20 @@ final class AgentMetricsMapper {
 
     private static String pauseText(long aMillis) {
         return aMillis < 0 ? "n/a" : aMillis + " ms";
+    }
+
+    private static long gcAvgPauseMs(TGcInfo aGc) {
+        return aGc != null && aGc.getAvgPauseMs() >= 0 ? Math.round(aGc.getAvgPauseMs()) : -1;
+    }
+
+    private static String gcAvgPauseText(TGcInfo aGc) {
+        return aGc != null && aGc.getAvgPauseMs() >= 0
+                ? String.format(Locale.ROOT, "%.1f ms", aGc.getAvgPauseMs())
+                : "n/a";
+    }
+
+    private static String gcLastCause(TGcInfo aGc) {
+        return aGc != null && aGc.getLastCause() != null ? aGc.getLastCause() : "n/a";
     }
 
     private static String duration(long aMillis) {

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentMetricsMapper.java
@@ -54,27 +54,27 @@ final class AgentMetricsMapper {
                 .processCpuTimeNanos(aInfo.getProcessCpuTimeNanos())
                 .processCpuTimeText(aInfo.getProcessCpuTimeNanos() < 0 ? "n/a" : duration(aInfo.getProcessCpuTimeNanos() / 1_000_000))
                 .heapUsedBytes(aInfo.getHeapUsedBytes())
-                .heapUsedText(bytes(aInfo.getHeapUsedBytes()))
+                .heapUsedText(MetricFormat.bytes(aInfo.getHeapUsedBytes()))
                 .heapCommittedBytes(aInfo.getHeapCommittedBytes())
-                .heapCommittedText(bytes(aInfo.getHeapCommittedBytes()))
+                .heapCommittedText(MetricFormat.bytes(aInfo.getHeapCommittedBytes()))
                 .heapMaxBytes(aInfo.getHeapMaxBytes())
-                .heapMaxText(bytes(aInfo.getHeapMaxBytes()))
+                .heapMaxText(MetricFormat.bytes(aInfo.getHeapMaxBytes()))
                 .heapUsedFraction(heapFraction)
                 .heapUsedPercentText(percent(heapFraction))
                 .nonHeapUsedBytes(aInfo.getNonHeapUsedBytes())
-                .nonHeapUsedText(bytes(aInfo.getNonHeapUsedBytes()))
+                .nonHeapUsedText(MetricFormat.bytes(aInfo.getNonHeapUsedBytes()))
                 .physicalUsedBytes(physicalUsed)
-                .physicalUsedText(bytes(physicalUsed))
+                .physicalUsedText(MetricFormat.bytes(physicalUsed))
                 .physicalTotalBytes(aInfo.getPhysicalTotalBytes())
-                .physicalTotalText(bytes(aInfo.getPhysicalTotalBytes()))
+                .physicalTotalText(MetricFormat.bytes(aInfo.getPhysicalTotalBytes()))
                 .physicalFreeBytes(aInfo.getPhysicalFreeBytes())
-                .physicalFreeText(bytes(aInfo.getPhysicalFreeBytes()))
+                .physicalFreeText(MetricFormat.bytes(aInfo.getPhysicalFreeBytes()))
                 .physicalUsedFraction(physicalFraction)
                 .physicalUsedPercentText(percent(physicalFraction))
                 .swapTotalBytes(aInfo.getSwapTotalBytes())
-                .swapTotalText(bytes(aInfo.getSwapTotalBytes()))
+                .swapTotalText(MetricFormat.bytes(aInfo.getSwapTotalBytes()))
                 .swapFreeBytes(aInfo.getSwapFreeBytes())
-                .swapFreeText(bytes(aInfo.getSwapFreeBytes()))
+                .swapFreeText(MetricFormat.bytes(aInfo.getSwapFreeBytes()))
                 .threadCount(aInfo.getThreadCount())
                 .gcCount(aInfo.getGcCount())
                 .gcTimeMs(aInfo.getGcTimeMs())
@@ -88,7 +88,7 @@ final class AgentMetricsMapper {
                 .gcLastPauseText(pauseText(gcLastPauseMs))
                 .gcLongPauseCount(gc != null ? gc.getLongPauseCount() : 0)
                 .gcLiveSetBytes(gcLiveSet)
-                .gcLiveSetText(bytes(gcLiveSet))
+                .gcLiveSetText(MetricFormat.bytes(gcLiveSet))
                 .gcLastCause(gc != null && gc.getLastCause() != null ? gc.getLastCause() : "n/a")
                 .gcHealthLevel(verdict.level().name())
                 .gcHealthSummary(verdict.summary())
@@ -103,23 +103,6 @@ final class AgentMetricsMapper {
 
     private static String pauseText(long aMillis) {
         return aMillis < 0 ? "n/a" : aMillis + " ms";
-    }
-
-    private static String bytes(long aBytes) {
-        if (aBytes < 0) {
-            return "n/a";
-        }
-        if (aBytes < 1024) {
-            return aBytes + " B";
-        }
-        String[] units = {"KB", "MB", "GB", "TB", "PB"};
-        double value = aBytes;
-        int    unit  = -1;
-        do {
-            value /= 1024;
-            unit++;
-        } while (value >= 1024 && unit < units.length - 1);
-        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
     }
 
     private static String duration(long aMillis) {

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
@@ -52,8 +52,9 @@ public class AgentServiceImpl implements IAgentService {
             return AgentListResponse.builder().agents(List.of()).build();
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(Math.min(agents.size(), MAX_THREADS));
-        try {
+        // try-with-resources: ExecutorService is AutoCloseable (Java 19+); close() shuts it down and
+        // waits for the already-joined tasks to finish. Replaces the manual finally-shutdown.
+        try (ExecutorService executor = Executors.newFixedThreadPool(Math.min(agents.size(), MAX_THREADS))) {
             List<TAgentInfo> result = agents.stream()
                     .map(agent -> CompletableFuture.supplyAsync(() -> toAgentInfo(agent), executor))
                     .toList()
@@ -63,8 +64,6 @@ public class AgentServiceImpl implements IAgentService {
                     .collect(toList());
 
             return AgentListResponse.builder().agents(result).build();
-        } finally {
-            executor.shutdown();
         }
     }
 

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
@@ -83,7 +83,7 @@ public class AgentServiceImpl implements IAgentService {
     private void fetchMetrics(TAgentHost agent, TAgentInfo.TAgentInfoBuilder builder) {
         try {
             SystemInfoResponse response = configService.agentClient(agent.getName()).getSystemInfo(SYSTEM_INFO_REQUEST);
-            builder.metrics(AgentMetricsMapper.toMetrics(response.getSystemInfo()));
+            builder.metrics(AgentMetricsMapper.toMetrics(agent.getName(), response.getSystemInfo()));
         } catch (Exception e) {
             LOG.warn("Cannot fetch metrics from agent {}", agent.getName(), e);
             builder.metricsError(e.getMessage());

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 
 public class AgentServiceImpl implements IAgentService {
 
@@ -61,7 +60,7 @@ public class AgentServiceImpl implements IAgentService {
                     .stream()
                     .map(CompletableFuture::join)
                     .sorted(comparing(TAgentInfo::getName))
-                    .collect(toList());
+                    .toList();
 
             return AgentListResponse.builder().agents(result).build();
         }

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
@@ -84,9 +84,7 @@ final class GcDoctor {
         }
 
         // Rule 4 — live set close to heap max after a collection ⇒ cramped, Full GC / OOM risk.
-        double liveFrac = heapMax > 0 && gc.getLiveSetAfterBytes() >= 0
-                ? (double) gc.getLiveSetAfterBytes() / heapMax
-                : -1;
+        double liveFrac = liveSetFraction(heapMax, gc.getLiveSetAfterBytes());
         if (liveFrac >= CRIT_HEAP_AFTER_FRAC) {
             findings.add(new Finding(Level.CRITICAL, String.format(Locale.ROOT,
                 "After the last GC the heap is still %.0f%% full (%s of %s) — the live set is near the "
@@ -116,13 +114,23 @@ final class GcDoctor {
                 findings);
         }
 
-        Level worst = findings.stream().anyMatch(f -> f.level() == Level.CRITICAL) ? Level.CRITICAL : Level.WARN;
-        String summary = findings.stream()
+        return summarize(findings);
+    }
+
+    /** Live set as a fraction of heap max, or -1 when either figure is unavailable. */
+    private static double liveSetFraction(long aHeapMax, long aLiveSetAfterBytes) {
+        return aHeapMax > 0 && aLiveSetAfterBytes >= 0 ? (double) aLiveSetAfterBytes / aHeapMax : -1;
+    }
+
+    /** Overall verdict from a non-empty finding list: worst level wins, its first message is the summary. */
+    private static Verdict summarize(List<Finding> aFindings) {
+        Level worst = aFindings.stream().anyMatch(f -> f.level() == Level.CRITICAL) ? Level.CRITICAL : Level.WARN;
+        String summary = aFindings.stream()
                 .filter(f -> f.level() == worst)
                 .map(Finding::message)
                 .findFirst()
                 .orElse("GC needs attention.");
-        return new Verdict(worst, summary, findings);
+        return new Verdict(worst, summary, aFindings);
     }
 
     private static String safeCause(TGcInfo gc) {

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
@@ -1,0 +1,156 @@
+package com.payneteasy.dcagent.operator.service.agent.impl;
+
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TSystemInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Turns raw GC numbers into a plain-English verdict, without an LLM. This is a fixed set of narrow
+ * rules: each rule is a boolean predicate over the readings, and each carries a pre-written message.
+ * A rule firing means "this pattern is present", not "the model understood the situation" — the
+ * text is a canned explanation attached to the condition, so the narrower the condition the more
+ * specific its message can honestly be.
+ *
+ * <p>What it can see: pause magnitude (last/avg/max), long-pause count, and the live-set trend
+ * (heap used after the last two GCs). What it cannot see: the user/sys/real CPU split from the
+ * unified GC log — the JMX notification does not carry it — so the "wall-clock &gt; cpu-time ⇒ the
+ * host, not the JVM" inference is not available here and is not claimed.
+ *
+ * <p>Severity ordering: CRITICAL &gt; WARN &gt; OK. The overall level is the worst finding.
+ */
+final class GcDoctor {
+
+    private GcDoctor() {
+    }
+
+    enum Level { OK, WARN, CRITICAL }
+
+    record Finding(Level level, String message) {
+    }
+
+    record Verdict(Level level, String summary, List<Finding> findings) {
+    }
+
+    // Tunables. Kept as constants here; promote to operator config if per-fleet tuning is needed.
+    private static final long   WARN_LAST_PAUSE_MS    = 100;
+    private static final long   CRIT_LAST_PAUSE_MS    = 500;
+    private static final long   WARN_MAX_PAUSE_MS     = 200;
+    private static final double CRIT_HEAP_AFTER_FRAC  = 0.80; // live set this close to max ⇒ trouble
+    private static final double WARN_HEAP_AFTER_FRAC  = 0.60;
+    private static final double LIVESET_GROWTH_FACTOR = 1.25; // last live set vs previous
+
+    /**
+     * Produce a verdict from the system info. {@code aInfo} carries heap max (for the live-set
+     * fraction) and the rich {@link TGcInfo}. Returns an "insufficient data" OK verdict when GC
+     * stats are not yet available.
+     */
+    static Verdict diagnose(TSystemInfo aInfo) {
+        TGcInfo gc = aInfo == null ? null : aInfo.getGc();
+        if (gc == null || gc.getCollectionCount() <= 0) {
+            return new Verdict(Level.OK, "No GC activity recorded yet — nothing to report.", List.of());
+        }
+
+        List<Finding> findings = new ArrayList<>();
+        long heapMax = aInfo.getHeapMaxBytes();
+
+        // Rule 1 — last pause magnitude.
+        if (gc.getLastPauseMs() >= CRIT_LAST_PAUSE_MS) {
+            findings.add(new Finding(Level.CRITICAL, String.format(Locale.ROOT,
+                "Last GC pause was %d ms (cause: %s) — a stop-the-world stall this long will be felt by callers.",
+                gc.getLastPauseMs(), safeCause(gc))));
+        } else if (gc.getLastPauseMs() >= WARN_LAST_PAUSE_MS) {
+            findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
+                "Last GC pause was %d ms (cause: %s) — above the comfortable range; watch for repeats.",
+                gc.getLastPauseMs(), safeCause(gc))));
+        }
+
+        // Rule 2 — worst pause ever seen (catches a spike that has since passed).
+        if (gc.getMaxPauseMs() >= WARN_MAX_PAUSE_MS && gc.getLastPauseMs() < WARN_LAST_PAUSE_MS) {
+            findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
+                "Longest pause so far was %d ms; current pauses are back to normal. Likely a one-off "
+                + "(host memory pressure / neighbours), not a standing JVM problem — confirm on the host.",
+                gc.getMaxPauseMs())));
+        }
+
+        // Rule 3 — recurring long pauses.
+        if (gc.getLongPauseCount() >= 3) {
+            findings.add(new Finding(Level.CRITICAL, String.format(Locale.ROOT,
+                "%d pauses have exceeded %d ms — recurring long stalls, not a one-off. Investigate heap "
+                + "sizing and host contention.",
+                gc.getLongPauseCount(), gc.getLongPauseThresholdMs())));
+        }
+
+        // Rule 4 — live set close to heap max after a collection ⇒ cramped, Full GC / OOM risk.
+        double liveFrac = heapMax > 0 && gc.getLiveSetAfterBytes() >= 0
+                ? (double) gc.getLiveSetAfterBytes() / heapMax
+                : -1;
+        if (liveFrac >= CRIT_HEAP_AFTER_FRAC) {
+            findings.add(new Finding(Level.CRITICAL, String.format(Locale.ROOT,
+                "After the last GC the heap is still %.0f%% full (%s of %s) — the live set is near the "
+                + "ceiling; Full GC or OOM is close. Raise -Xmx or find what is retained.",
+                liveFrac * 100, bytes(gc.getLiveSetAfterBytes()), bytes(heapMax))));
+        } else if (liveFrac >= WARN_HEAP_AFTER_FRAC) {
+            findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
+                "After the last GC the heap is %.0f%% full — getting tight, keep an eye on it.",
+                liveFrac * 100)));
+        }
+
+        // Rule 5 — live set jumped between the last two collections ⇒ possible leak / accumulation.
+        long prev = gc.getPrevLiveSetAfterBytes();
+        long last = gc.getLiveSetAfterBytes();
+        if (prev > 0 && last > 0 && last > prev * LIVESET_GROWTH_FACTOR) {
+            findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
+                "Live set grew from %s to %s between the last two collections — could be normal load or "
+                + "the start of a leak. If it keeps climbing, take a heap dump.",
+                bytes(prev), bytes(last))));
+        }
+
+        if (findings.isEmpty()) {
+            return new Verdict(Level.OK, String.format(Locale.ROOT,
+                "GC healthy: %d collections, avg %s, max %s, live set %s. No leak or pressure signs.",
+                gc.getCollectionCount(), ms(gc.getAvgPauseMs()), msLong(gc.getMaxPauseMs()),
+                bytes(gc.getLiveSetAfterBytes())),
+                findings);
+        }
+
+        Level worst = findings.stream().anyMatch(f -> f.level() == Level.CRITICAL) ? Level.CRITICAL : Level.WARN;
+        String summary = findings.stream()
+                .filter(f -> f.level() == worst)
+                .map(Finding::message)
+                .findFirst()
+                .orElse("GC needs attention.");
+        return new Verdict(worst, summary, findings);
+    }
+
+    private static String safeCause(TGcInfo gc) {
+        return gc.getLastCause() == null ? "unknown" : gc.getLastCause();
+    }
+
+    private static String ms(double aMs) {
+        return aMs < 0 ? "n/a" : String.format(Locale.ROOT, "%.1f ms", aMs);
+    }
+
+    private static String msLong(long aMs) {
+        return aMs < 0 ? "n/a" : aMs + " ms";
+    }
+
+    private static String bytes(long aBytes) {
+        if (aBytes < 0) {
+            return "n/a";
+        }
+        if (aBytes < 1024) {
+            return aBytes + " B";
+        }
+        String[] units = {"KB", "MB", "GB", "TB"};
+        double value = aBytes;
+        int    unit  = -1;
+        do {
+            value /= 1024;
+            unit++;
+        } while (value >= 1024 && unit < units.length - 1);
+        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
+    }
+}

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctor.java
@@ -91,7 +91,7 @@ final class GcDoctor {
             findings.add(new Finding(Level.CRITICAL, String.format(Locale.ROOT,
                 "After the last GC the heap is still %.0f%% full (%s of %s) — the live set is near the "
                 + "ceiling; Full GC or OOM is close. Raise -Xmx or find what is retained.",
-                liveFrac * 100, bytes(gc.getLiveSetAfterBytes()), bytes(heapMax))));
+                liveFrac * 100, MetricFormat.bytes(gc.getLiveSetAfterBytes()), MetricFormat.bytes(heapMax))));
         } else if (liveFrac >= WARN_HEAP_AFTER_FRAC) {
             findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
                 "After the last GC the heap is %.0f%% full — getting tight, keep an eye on it.",
@@ -105,14 +105,14 @@ final class GcDoctor {
             findings.add(new Finding(Level.WARN, String.format(Locale.ROOT,
                 "Live set grew from %s to %s between the last two collections — could be normal load or "
                 + "the start of a leak. If it keeps climbing, take a heap dump.",
-                bytes(prev), bytes(last))));
+                MetricFormat.bytes(prev), MetricFormat.bytes(last))));
         }
 
         if (findings.isEmpty()) {
             return new Verdict(Level.OK, String.format(Locale.ROOT,
                 "GC healthy: %d collections, avg %s, max %s, live set %s. No leak or pressure signs.",
                 gc.getCollectionCount(), ms(gc.getAvgPauseMs()), msLong(gc.getMaxPauseMs()),
-                bytes(gc.getLiveSetAfterBytes())),
+                MetricFormat.bytes(gc.getLiveSetAfterBytes())),
                 findings);
         }
 
@@ -135,22 +135,5 @@ final class GcDoctor {
 
     private static String msLong(long aMs) {
         return aMs < 0 ? "n/a" : aMs + " ms";
-    }
-
-    private static String bytes(long aBytes) {
-        if (aBytes < 0) {
-            return "n/a";
-        }
-        if (aBytes < 1024) {
-            return aBytes + " B";
-        }
-        String[] units = {"KB", "MB", "GB", "TB"};
-        double value = aBytes;
-        int    unit  = -1;
-        do {
-            value /= 1024;
-            unit++;
-        } while (value >= 1024 && unit < units.length - 1);
-        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
     }
 }

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
@@ -18,6 +18,8 @@ import java.util.Locale;
  */
 final class GcLlmPayloadBuilder {
 
+    private static final String MS_LINE = " ms\n";
+
     private GcLlmPayloadBuilder() {
     }
 
@@ -46,10 +48,10 @@ final class GcLlmPayloadBuilder {
 
         b.append("## GC statistics\n");
         b.append("collections: ").append(gc.getCollectionCount()).append('\n');
-        b.append("total pause: ").append(gc.getTotalPauseMs()).append(" ms\n");
-        b.append("avg pause: ").append(fmt(gc.getAvgPauseMs())).append(" ms\n");
-        b.append("max pause: ").append(gc.getMaxPauseMs()).append(" ms\n");
-        b.append("last pause: ").append(gc.getLastPauseMs()).append(" ms\n");
+        b.append("total pause: ").append(gc.getTotalPauseMs()).append(MS_LINE);
+        b.append("avg pause: ").append(fmt(gc.getAvgPauseMs())).append(MS_LINE);
+        b.append("max pause: ").append(gc.getMaxPauseMs()).append(MS_LINE);
+        b.append("last pause: ").append(gc.getLastPauseMs()).append(MS_LINE);
         b.append("pauses over ").append(gc.getLongPauseThresholdMs()).append(" ms: ")
          .append(gc.getLongPauseCount()).append('\n');
         b.append("last cause: ").append(gc.getLastCause() == null ? "n/a" : gc.getLastCause()).append('\n');

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
@@ -1,0 +1,109 @@
+package com.payneteasy.dcagent.operator.service.agent.impl;
+
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TSystemInfo;
+
+import java.util.Locale;
+
+/**
+ * Builds a self-contained plain-text block the operator can copy and paste into an LLM. It bundles
+ * the raw GC readings plus the surrounding host/JVM context (heap sizing, physical memory, swap,
+ * CPU) and a short instruction, so the model has everything it needs to reason the way a human
+ * would over a GC log — including context the JVM itself cannot see (that memory is shared with
+ * other processes on the box).
+ *
+ * <p>This is the "escape hatch" beside the deterministic {@link GcDoctor} verdict: the rules give an
+ * instant, stable answer; this payload lets a model give a contextual one when the rules are not
+ * enough.
+ */
+final class GcLlmPayloadBuilder {
+
+    private GcLlmPayloadBuilder() {
+    }
+
+    static String build(String aAgentName, TSystemInfo aInfo) {
+        TGcInfo gc = aInfo == null ? null : aInfo.getGc();
+        StringBuilder b = new StringBuilder(1024);
+
+        b.append("You are a JVM garbage-collection expert. Below are GC statistics and host context ")
+         .append("collected from a running Java service. Explain in plain language what is happening ")
+         .append("with GC, whether anything looks wrong, and what to check or change. Note that heap ")
+         .append("memory is shared with other processes on the host, so consider host memory pressure ")
+         .append("and swap, not just the JVM.\n\n");
+
+        b.append("## Agent\n");
+        b.append("name: ").append(aAgentName).append('\n');
+        if (aInfo != null) {
+            b.append("uptime: ").append(aInfo.getProcessCpuTimeNanos() < 0 ? "n/a"
+                    : (aInfo.getProcessCpuTimeNanos() / 1_000_000_000) + "s of CPU").append('\n');
+        }
+        b.append('\n');
+
+        if (gc == null || gc.getCollectionCount() <= 0) {
+            b.append("## GC\nNo garbage collections have happened yet — nothing to analyse.\n");
+            return b.toString();
+        }
+
+        b.append("## GC statistics\n");
+        b.append("collections: ").append(gc.getCollectionCount()).append('\n');
+        b.append("total pause: ").append(gc.getTotalPauseMs()).append(" ms\n");
+        b.append("avg pause: ").append(fmt(gc.getAvgPauseMs())).append(" ms\n");
+        b.append("max pause: ").append(gc.getMaxPauseMs()).append(" ms\n");
+        b.append("last pause: ").append(gc.getLastPauseMs()).append(" ms\n");
+        b.append("pauses over ").append(gc.getLongPauseThresholdMs()).append(" ms: ")
+         .append(gc.getLongPauseCount()).append('\n');
+        b.append("last cause: ").append(gc.getLastCause() == null ? "n/a" : gc.getLastCause()).append('\n');
+        b.append("last action: ").append(gc.getLastAction() == null ? "n/a" : gc.getLastAction()).append('\n');
+        b.append("live set after last GC: ").append(bytes(gc.getLiveSetAfterBytes())).append('\n');
+        b.append("live set after previous GC: ").append(bytes(gc.getPrevLiveSetAfterBytes())).append('\n');
+        b.append('\n');
+
+        if (aInfo != null) {
+            b.append("## Heap / memory context\n");
+            b.append("heap used: ").append(bytes(aInfo.getHeapUsedBytes())).append('\n');
+            b.append("heap committed: ").append(bytes(aInfo.getHeapCommittedBytes())).append('\n');
+            b.append("heap max: ").append(bytes(aInfo.getHeapMaxBytes())).append('\n');
+            b.append("non-heap used: ").append(bytes(aInfo.getNonHeapUsedBytes())).append('\n');
+            b.append("physical total: ").append(bytes(aInfo.getPhysicalTotalBytes())).append('\n');
+            b.append("physical free: ").append(bytes(aInfo.getPhysicalFreeBytes())).append('\n');
+            b.append("swap total: ").append(bytes(aInfo.getSwapTotalBytes())).append('\n');
+            b.append("swap free: ").append(bytes(aInfo.getSwapFreeBytes())).append('\n');
+            b.append('\n');
+
+            b.append("## CPU context\n");
+            b.append("processors: ").append(aInfo.getAvailableProcessors()).append('\n');
+            b.append("load average: ").append(aInfo.getLoadAverage() < 0 ? "n/a"
+                    : String.format(Locale.ROOT, "%.2f", aInfo.getLoadAverage())).append('\n');
+            b.append("system CPU: ").append(pct(aInfo.getSystemCpuLoad())).append('\n');
+            b.append("process CPU: ").append(pct(aInfo.getProcessCpuLoad())).append('\n');
+            b.append("threads: ").append(aInfo.getThreadCount()).append('\n');
+        }
+
+        return b.toString();
+    }
+
+    private static String fmt(double aValue) {
+        return aValue < 0 ? "n/a" : String.format(Locale.ROOT, "%.1f", aValue);
+    }
+
+    private static String pct(double aFraction) {
+        return aFraction < 0 ? "n/a" : Math.round(aFraction * 100) + "%";
+    }
+
+    private static String bytes(long aBytes) {
+        if (aBytes < 0) {
+            return "n/a";
+        }
+        if (aBytes < 1024) {
+            return aBytes + " B";
+        }
+        String[] units = {"KB", "MB", "GB", "TB"};
+        double value = aBytes;
+        int    unit  = -1;
+        do {
+            value /= 1024;
+            unit++;
+        } while (value >= 1024 && unit < units.length - 1);
+        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
+    }
+}

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/GcLlmPayloadBuilder.java
@@ -54,30 +54,30 @@ final class GcLlmPayloadBuilder {
          .append(gc.getLongPauseCount()).append('\n');
         b.append("last cause: ").append(gc.getLastCause() == null ? "n/a" : gc.getLastCause()).append('\n');
         b.append("last action: ").append(gc.getLastAction() == null ? "n/a" : gc.getLastAction()).append('\n');
-        b.append("live set after last GC: ").append(bytes(gc.getLiveSetAfterBytes())).append('\n');
-        b.append("live set after previous GC: ").append(bytes(gc.getPrevLiveSetAfterBytes())).append('\n');
+        b.append("live set after last GC: ").append(MetricFormat.bytes(gc.getLiveSetAfterBytes())).append('\n');
+        b.append("live set after previous GC: ").append(MetricFormat.bytes(gc.getPrevLiveSetAfterBytes())).append('\n');
         b.append('\n');
 
-        if (aInfo != null) {
-            b.append("## Heap / memory context\n");
-            b.append("heap used: ").append(bytes(aInfo.getHeapUsedBytes())).append('\n');
-            b.append("heap committed: ").append(bytes(aInfo.getHeapCommittedBytes())).append('\n');
-            b.append("heap max: ").append(bytes(aInfo.getHeapMaxBytes())).append('\n');
-            b.append("non-heap used: ").append(bytes(aInfo.getNonHeapUsedBytes())).append('\n');
-            b.append("physical total: ").append(bytes(aInfo.getPhysicalTotalBytes())).append('\n');
-            b.append("physical free: ").append(bytes(aInfo.getPhysicalFreeBytes())).append('\n');
-            b.append("swap total: ").append(bytes(aInfo.getSwapTotalBytes())).append('\n');
-            b.append("swap free: ").append(bytes(aInfo.getSwapFreeBytes())).append('\n');
-            b.append('\n');
+        // aInfo is guaranteed non-null here: gc is non-null (we returned above otherwise), and gc is
+        // only non-null when aInfo was non-null (see the gc assignment at the top of this method).
+        b.append("## Heap / memory context\n");
+        b.append("heap used: ").append(MetricFormat.bytes(aInfo.getHeapUsedBytes())).append('\n');
+        b.append("heap committed: ").append(MetricFormat.bytes(aInfo.getHeapCommittedBytes())).append('\n');
+        b.append("heap max: ").append(MetricFormat.bytes(aInfo.getHeapMaxBytes())).append('\n');
+        b.append("non-heap used: ").append(MetricFormat.bytes(aInfo.getNonHeapUsedBytes())).append('\n');
+        b.append("physical total: ").append(MetricFormat.bytes(aInfo.getPhysicalTotalBytes())).append('\n');
+        b.append("physical free: ").append(MetricFormat.bytes(aInfo.getPhysicalFreeBytes())).append('\n');
+        b.append("swap total: ").append(MetricFormat.bytes(aInfo.getSwapTotalBytes())).append('\n');
+        b.append("swap free: ").append(MetricFormat.bytes(aInfo.getSwapFreeBytes())).append('\n');
+        b.append('\n');
 
-            b.append("## CPU context\n");
-            b.append("processors: ").append(aInfo.getAvailableProcessors()).append('\n');
-            b.append("load average: ").append(aInfo.getLoadAverage() < 0 ? "n/a"
-                    : String.format(Locale.ROOT, "%.2f", aInfo.getLoadAverage())).append('\n');
-            b.append("system CPU: ").append(pct(aInfo.getSystemCpuLoad())).append('\n');
-            b.append("process CPU: ").append(pct(aInfo.getProcessCpuLoad())).append('\n');
-            b.append("threads: ").append(aInfo.getThreadCount()).append('\n');
-        }
+        b.append("## CPU context\n");
+        b.append("processors: ").append(aInfo.getAvailableProcessors()).append('\n');
+        b.append("load average: ").append(aInfo.getLoadAverage() < 0 ? "n/a"
+                : String.format(Locale.ROOT, "%.2f", aInfo.getLoadAverage())).append('\n');
+        b.append("system CPU: ").append(pct(aInfo.getSystemCpuLoad())).append('\n');
+        b.append("process CPU: ").append(pct(aInfo.getProcessCpuLoad())).append('\n');
+        b.append("threads: ").append(aInfo.getThreadCount()).append('\n');
 
         return b.toString();
     }
@@ -88,22 +88,5 @@ final class GcLlmPayloadBuilder {
 
     private static String pct(double aFraction) {
         return aFraction < 0 ? "n/a" : Math.round(aFraction * 100) + "%";
-    }
-
-    private static String bytes(long aBytes) {
-        if (aBytes < 0) {
-            return "n/a";
-        }
-        if (aBytes < 1024) {
-            return aBytes + " B";
-        }
-        String[] units = {"KB", "MB", "GB", "TB"};
-        double value = aBytes;
-        int    unit  = -1;
-        do {
-            value /= 1024;
-            unit++;
-        } while (value >= 1024 && unit < units.length - 1);
-        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
     }
 }

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/MetricFormat.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/impl/MetricFormat.java
@@ -1,0 +1,32 @@
+package com.payneteasy.dcagent.operator.service.agent.impl;
+
+import java.util.Locale;
+
+/**
+ * Shared metric formatting helpers used by {@link AgentMetricsMapper} and the GC diagnostics classes
+ * ({@link GcDoctor}, {@link GcLlmPayloadBuilder}). Kept in one place so the byte-scale rendering is
+ * defined once rather than copied per class.
+ */
+final class MetricFormat {
+
+    private MetricFormat() {
+    }
+
+    /** Human-readable byte size (B/KB/MB/GB/TB/PB), or {@code "n/a"} for a negative sentinel. */
+    static String bytes(long aBytes) {
+        if (aBytes < 0) {
+            return "n/a";
+        }
+        if (aBytes < 1024) {
+            return aBytes + " B";
+        }
+        String[] units = {"KB", "MB", "GB", "TB", "PB"};
+        double value = aBytes;
+        int    unit  = -1;
+        do {
+            value /= 1024;
+            unit++;
+        } while (value >= 1024 && unit < units.length - 1);
+        return String.format(Locale.ROOT, "%.1f %s", value, units[unit]);
+    }
+}

--- a/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/model/TAgentMetrics.java
+++ b/dc-agent-operator/src/main/java/com/payneteasy/dcagent/operator/service/agent/model/TAgentMetrics.java
@@ -53,9 +53,29 @@ public class TAgentMetrics {
     long   swapFreeBytes;
     String swapFreeText;
 
-    // Threads + GC
+    // Threads + GC (cumulative)
     int    threadCount;
     long   gcCount;
     long   gcTimeMs;
     String gcTimeText;
+
+    // Rich GC statistics (per-pause). Raw values for sorting + *Text for display.
+    long   gcAvgPauseMs;          // -1 = n/a
+    String gcAvgPauseText;
+    long   gcMaxPauseMs;          // -1 = n/a
+    String gcMaxPauseText;
+    long   gcLastPauseMs;         // -1 = n/a
+    String gcLastPauseText;
+    long   gcLongPauseCount;
+    long   gcLiveSetBytes;        // heap used after last GC, -1 = n/a
+    String gcLiveSetText;
+    String gcLastCause;
+
+    // Deterministic verdict (no LLM). Level is OK / WARN / CRITICAL for a status indicator.
+    String gcHealthLevel;
+    String gcHealthSummary;       // one-line headline
+    String gcHealthDetail;        // full multi-line findings, newline-joined
+
+    // Ready-to-paste block for an LLM (the "copy for LLM" button copies this verbatim).
+    String gcLlmPayload;
 }

--- a/dc-agent-operator/src/test/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImplTest.java
+++ b/dc-agent-operator/src/test/java/com/payneteasy/dcagent/operator/service/agent/impl/AgentServiceImplTest.java
@@ -8,9 +8,11 @@ import com.payneteasy.dcagent.core.remote.agent.controlplane.messages.*;
 import com.payneteasy.dcagent.core.remote.agent.controlplane.model.ServiceInfoItem;
 import com.payneteasy.dcagent.core.remote.agent.controlplane.model.ServiceStateType;
 import com.payneteasy.dcagent.core.remote.agent.controlplane.model.ServiceStatus;
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
 import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TSystemInfo;
 import com.payneteasy.dcagent.operator.service.agent.messages.AgentListResponse;
 import com.payneteasy.dcagent.operator.service.agent.model.TAgentInfo;
+import com.payneteasy.dcagent.operator.service.agent.model.TAgentMetrics;
 import com.payneteasy.dcagent.operator.service.config.IOperatorConfigService;
 import com.payneteasy.dcagent.operator.service.config.model.TAgentHost;
 import com.payneteasy.dcagent.operator.service.config.model.TOperatorConfig;
@@ -60,6 +62,12 @@ public class AgentServiceImplTest {
         assertNotNull(alpha.getMetrics());
         assertEquals(42, alpha.getMetrics().getThreadCount());
         assertNull(alpha.getMetricsError());
+        // Rich GC figures are mapped through GcDoctor + GcLlmPayloadBuilder.
+        assertEquals("OK", alpha.getMetrics().getGcHealthLevel());
+        assertTrue(alpha.getMetrics().getGcHealthSummary().contains("GC healthy"));
+        assertEquals(30, alpha.getMetrics().getGcMaxPauseMs());
+        assertEquals("30 ms", alpha.getMetrics().getGcMaxPauseText());
+        assertTrue(alpha.getMetrics().getGcLlmPayload().contains("alpha"));
 
         TAgentInfo bravo = agents.get(1);
         assertFalse(bravo.isReachable());
@@ -67,6 +75,18 @@ public class AgentServiceImplTest {
         assertTrue(bravo.getServicesError().contains("down"));
         assertEquals(0, bravo.getServicesTotal());
         assertNotNull(bravo.getMetricsError());
+    }
+
+    @Test
+    public void mapper_nullGc_degradesToNaAndOkVerdict() {
+        TAgentMetrics metrics = AgentMetricsMapper.toMetrics("gamma", TSystemInfo.builder().heapMaxBytes(-1).build());
+
+        assertEquals("OK", metrics.getGcHealthLevel());
+        assertEquals(-1, metrics.getGcMaxPauseMs());
+        assertEquals("n/a", metrics.getGcMaxPauseText());
+        assertEquals("n/a", metrics.getGcLastCause());
+        assertEquals(0, metrics.getGcLongPauseCount());
+        assertTrue(metrics.getGcLlmPayload().contains("No garbage collections have happened yet"));
     }
 
     private static ServiceInfoItem service(String name, ServiceStateType state) {
@@ -163,6 +183,20 @@ public class AgentServiceImplTest {
                             .threadCount(42)
                             .gcCount(10)
                             .gcTimeMs(1200)
+                            .gc(TGcInfo.builder()
+                                    .collectionCount(10)
+                                    .totalPauseMs(200)
+                                    .avgPauseMs(20)
+                                    .maxPauseMs(30)
+                                    .lastPauseMs(20)
+                                    .lastGcEpochMs(1)
+                                    .longPauseCount(0)
+                                    .longPauseThresholdMs(200)
+                                    .liveSetAfterBytes(268_435_456L)
+                                    .prevLiveSetAfterBytes(268_435_456L)
+                                    .lastCause("G1 Young Generation")
+                                    .lastAction("end of minor GC")
+                                    .build())
                             .build())
                     .build();
         }

--- a/dc-agent-operator/src/test/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctorTest.java
+++ b/dc-agent-operator/src/test/java/com/payneteasy/dcagent/operator/service/agent/impl/GcDoctorTest.java
@@ -1,0 +1,139 @@
+package com.payneteasy.dcagent.operator.service.agent.impl;
+
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TGcInfo;
+import com.payneteasy.dcagent.core.remote.agent.controlplane.model.TSystemInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Each test crafts a {@link TGcInfo} that isolates a single rule so we can assert both the level and
+ * the honest wording. The heap max is fixed at 1 GB so the live-set fractions are easy to reason
+ * about.
+ */
+public class GcDoctorTest {
+
+    private static final long HEAP_MAX = 1_000_000_000L; // ~1 GB, keeps the live-set math obvious
+
+    /** A quiet, healthy collector: small pauses, tiny live set, no growth. */
+    private static TGcInfo.TGcInfoBuilder healthyGc() {
+        return TGcInfo.builder()
+                .collectionCount(10)
+                .totalPauseMs(200)
+                .avgPauseMs(20)
+                .maxPauseMs(30)
+                .lastPauseMs(20)
+                .lastGcEpochMs(1)
+                .longPauseCount(0)
+                .longPauseThresholdMs(200)
+                .liveSetAfterBytes(100_000_000L)   // 10 % of heap
+                .prevLiveSetAfterBytes(100_000_000L)
+                .lastCause("G1 Evacuation Pause")
+                .lastAction("end of minor GC");
+    }
+
+    private static TSystemInfo sys(TGcInfo gc) {
+        return TSystemInfo.builder().heapMaxBytes(HEAP_MAX).gc(gc).build();
+    }
+
+    @Test
+    public void nullGc_isOk_noActivity() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(TSystemInfo.builder().heapMaxBytes(HEAP_MAX).build());
+        assertEquals(GcDoctor.Level.OK, verdict.level());
+        assertTrue(verdict.findings().isEmpty());
+        assertTrue(verdict.summary().contains("No GC activity"));
+    }
+
+    @Test
+    public void zeroCollections_isOk_noActivity() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc().collectionCount(0).build()));
+        assertEquals(GcDoctor.Level.OK, verdict.level());
+    }
+
+    @Test
+    public void healthy_isOk_withSummary() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc().build()));
+        assertEquals(GcDoctor.Level.OK, verdict.level());
+        assertTrue(verdict.findings().isEmpty());
+        assertTrue(verdict.summary().contains("GC healthy"));
+    }
+
+    @Test
+    public void lastPauseVeryLong_isCritical() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .lastPauseMs(600).maxPauseMs(600).longPauseCount(1).build()));
+        assertEquals(GcDoctor.Level.CRITICAL, verdict.level());
+        assertTrue(verdict.summary().contains("600 ms"));
+    }
+
+    @Test
+    public void lastPauseElevated_isWarn() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .lastPauseMs(150).maxPauseMs(150).build()));
+        assertEquals(GcDoctor.Level.WARN, verdict.level());
+        assertTrue(verdict.summary().contains("watch for repeats"));
+    }
+
+    @Test
+    public void worstPauseHighButCurrentNormal_isWarn_oneOff() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .maxPauseMs(300).lastPauseMs(50).build()));
+        assertEquals(GcDoctor.Level.WARN, verdict.level());
+        assertTrue(verdict.summary().contains("one-off"));
+    }
+
+    @Test
+    public void recurringLongPauses_isCritical() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .longPauseCount(5).longPauseThresholdMs(200).build()));
+        assertEquals(GcDoctor.Level.CRITICAL, verdict.level());
+        assertTrue(verdict.summary().contains("recurring long stalls"));
+    }
+
+    @Test
+    public void liveSetNearHeapMax_isCritical() {
+        long near = (long) (HEAP_MAX * 0.85);
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .liveSetAfterBytes(near).prevLiveSetAfterBytes(near).build()));
+        assertEquals(GcDoctor.Level.CRITICAL, verdict.level());
+        assertTrue(verdict.summary().contains("OOM"));
+    }
+
+    @Test
+    public void liveSetGettingTight_isWarn() {
+        long tight = (long) (HEAP_MAX * 0.70);
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .liveSetAfterBytes(tight).prevLiveSetAfterBytes(tight).build()));
+        assertEquals(GcDoctor.Level.WARN, verdict.level());
+        assertTrue(verdict.summary().contains("getting tight"));
+    }
+
+    @Test
+    public void liveSetJumped_isWarn_possibleLeak() {
+        GcDoctor.Verdict verdict = GcDoctor.diagnose(sys(healthyGc()
+                .prevLiveSetAfterBytes(100_000_000L).liveSetAfterBytes(200_000_000L).build()));
+        assertEquals(GcDoctor.Level.WARN, verdict.level());
+        assertTrue(verdict.summary().contains("Live set grew"));
+    }
+
+    @Test
+    public void payload_containsAgentName_instruction_andRawNumbers() {
+        String payload = GcLlmPayloadBuilder.build("test-agent", sys(healthyGc()
+                .collectionCount(10).maxPauseMs(600).lastPauseMs(600).build()));
+        assertTrue(payload.contains("test-agent"));
+        assertTrue(payload.contains("You are a JVM garbage-collection expert"));
+        assertTrue(payload.contains("collections: 10"));
+        assertTrue(payload.contains("max pause: 600 ms"));
+        assertTrue(payload.contains("last cause: G1 Evacuation Pause"));
+    }
+
+    @Test
+    public void payload_nullGc_saysNothingToAnalyse() {
+        String payload = GcLlmPayloadBuilder.build("test-agent", TSystemInfo.builder().build());
+        assertTrue(payload.contains("test-agent"));
+        assertTrue(payload.contains("No garbage collections have happened yet"));
+        assertFalse(payload.contains("## GC statistics"));
+    }
+}


### PR DESCRIPTION
## What

Extends the existing agent metrics pipeline with **rich per-pause GC statistics** and a **deterministic, LLM-free GC health verdict**, surfaced in the operator UI. No LLM/network call is made by the backend — the verdict is pure rules and the "copy for LLM" feature only prepares text.

Pairs with the frontend PR: evsinev/dc-agent-react#1 (branch `feature/gc-diagnostics`).

## Changes

- **dc-agent-core**: new `TGcInfo` DTO (per-pause aggregates, `-1` sentinels); add nullable `TSystemInfo.gc`.
- **dc-agent-app**: `GcStatsCollector` subscribes to `GarbageCollectionNotificationInfo` JMX notifications and keeps **bounded aggregates only** (atomics/`LongAdder`, no per-event history); wired into `SystemInfoCollector` (`install()` on start, `snapshot()` in `collect()`). Constructor stays no-arg, so `DcAgentApplication` is untouched.
- **dc-agent-operator**:
  - `GcDoctor` — 5 narrow, pre-worded rules → `OK/WARN/CRITICAL` verdict (overall = worst finding).
  - `GcLlmPayloadBuilder` — self-contained copy-for-LLM text block (raw GC numbers + host/JVM context + instruction).
  - `TAgentMetrics` + `AgentMetricsMapper` extended (raw value + `*Text` per convention, null-`gc` guards → `-1`/`n/a`/OK verdict); agent name threaded through `AgentServiceImpl.fetchMetrics`.

> Note: the JMX notification does **not** carry the user/sys/real CPU split from the unified GC log, so the "wall-clock > cpu-time ⇒ host not JVM" inference is not available here and is not faked.

## Tests

- `GcDoctorTest` — each rule (OK/WARN/CRITICAL), the healthy verdict, the null-`gc` fallback, and payload contents (agent name, instruction line, raw numbers).
- `AgentServiceImplTest` — asserts the mapped verdict/payload for a reachable agent + a direct null-`gc` mapper check.
- `./mvnw -pl dc-agent-core,dc-agent-app,dc-agent-operator -am install` green; **89 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)