### PR TITLE
fix(logging): single-line startup logs (bridge JUL to SLF4J)

### DIFF
--- a/dc-agent-app/src/main/java/com/payneteasy/dcagent/DcAgentApplication.java
+++ b/dc-agent-app/src/main/java/com/payneteasy/dcagent/DcAgentApplication.java
@@ -35,6 +35,7 @@ import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class DcAgentApplication {
 
@@ -43,6 +44,11 @@ public class DcAgentApplication {
     private Server jetty;
 
     public static void main(String[] args) {
+        // Route java.util.logging (used by the startup-parameters lib) through SLF4J/Logback
+        // so the "Startup parameters" block prints in the same single-line format as the rest.
+        // Must run before getStartupParameters(); removeHandlers avoids double (two-line + one-line) output.
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
         try {
             IStartupConfig     startupConfig = StartupParametersFactory.getStartupParameters(IStartupConfig.class);
             DcAgentApplication app           = new DcAgentApplication();

--- a/dc-agent-app/src/main/resources/logback.xml
+++ b/dc-agent-app/src/main/resources/logback.xml
@@ -1,6 +1,11 @@
 <configuration>
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
+    <!-- Sync java.util.logging levels with Logback (used together with SLF4JBridgeHandler in DcAgentApplication) -->
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy.MM.dd HH:mm:ss.SSS} [%thread] %-5level %-20.20logger - %msg%n</pattern>


### PR DESCRIPTION
## Problem

At agent startup the log had **two formats**: the `Startup parameters` block from the private `com.payneteasy:startup-parameters` lib printed via `java.util.logging` (JUL) in the default two-line `SimpleFormatter`, while everything else logged via SLF4J/Logback in one line.

Root cause: `org.slf4j:jul-to-slf4j` is already a dependency, but the bridge was never installed, so JUL records went to the JDK default `ConsoleHandler` (two-line), bypassing Logback.

## Change

- `DcAgentApplication.main()` — install the JUL→SLF4J bridge as the very first thing (before `getStartupParameters()`), with `removeHandlersForRootLogger()` to avoid double output.
- `logback.xml` — add `LevelChangePropagator` to sync JUL levels (best-practice companion to the bridge).

No pom or launcher-script changes (dependency was already present).

## Result

The `Startup parameters` block now prints single-line in the same Logback format as the rest, no duplication:

```
2026.07.23 03:30:41.170 [main] INFO  ersInvocationHandler - Startup parameters:
2026.07.23 03:30:41.171 [main] INFO  ersInvocationHandler -     d APP_INSTANCE_NAME = dc-agent
...
2026.07.23 03:30:41.361 [main] INFO  ttyContextRepository - Adding servlet /zip-archive/*
```

## Verification

- `./mvnw -Pagent-shaded -pl dc-agent-app -am package` — 43 tests pass, `dc-agent.jar` builds.
- Ran the jar: startup block is single-line, no `NoClassDefFound`/`LinkageError`.

## Notes

- `dc-agent-operator` has the same latent issue (starts via `mini-core` `AppRunner`); not touched here.
- GraalVM native build: verify `SLF4JBridgeHandler`/`LevelChangePropagator` reachability if building native.