### PR TITLE
fix(owasp): correct OSS Index disable flag casing

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -110,7 +110,7 @@ jobs:
           -Dformat=SARIF
           -DprettyPrint=true
           -DfailBuildOnCVSS=8
-          -DossindexAnalyzerEnabled=false
+          -DossIndexAnalyzerEnabled=false
           -DsuppressionFiles=owasp-suppressions.xml
           -DdataDirectory=$HOME/.dependency-check-data
           -DautoUpdate=false


### PR DESCRIPTION
## Problem

The OWASP job logs:
```
[WARNING] Sonatype OSS Index Analyzer disabled due to missing credentials. Authentication with token is now required...
```
OSS Index now requires a token and auto-disables itself (with this warning) when none is present. We intend to keep it disabled — but the disable flag wasn't taking effect.

## Root cause — property casing

In dependency-check-maven 12.2.2 the field is declared:
```java
@Parameter(property = "ossIndexAnalyzerEnabled", alias = "ossindexAnalyzerEnabled")
```
A Maven `-D` user property binds only to `property` (`ossIndexAnalyzerEnabled`, capital **I**). The `alias` (lowercase) applies only to the POM `<configuration>` element, **not** to `-D`. The workflow passed `-DossindexAnalyzerEnabled=false` (lowercase i), so it was silently ignored → OSS Index stayed enabled by default → self-disabled with the warning.

## Change

`.github/workflows/dependency-scan.yml` (owasp scan step): `-DossindexAnalyzerEnabled=false` → `-DossIndexAnalyzerEnabled=false`. One character (i → I). Now the analyzer is actually disabled and never runs its credential check.

## Verification

Next `OWASP Dependency-Check` run: no `Sonatype OSS Index Analyzer disabled due to missing credentials` line; scan still green on NVD data.