### PR TITLE
ci(owasp): enable OSS Index analyzer via token auth

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -99,18 +99,26 @@ jobs:
           key: nvd-${{ steps.nvd.outputs.day }}
           restore-keys: nvd-
 
-      # Scan against the pre-populated DB. autoUpdate=false → no NVD download and no
-      # API key needed, so this also works on Dependabot PRs (which don't get regular
-      # Actions secrets). failBuildOnCVSS=8 fails only on a real CVSS >= 8 (the report
-      # is written first, so the uploads below still run).
+      # Scan against the pre-populated NVD DB (autoUpdate=false → no NVD download).
+      # OSS Index adds Sonatype's data via token auth; on Dependabot PRs the OSS Index
+      # secrets are absent, so that analyzer is skipped (harmless) and only NVD is used.
+      # ossIndexWarnOnlyOnRemoteErrors keeps a Sonatype outage/rate-limit from failing
+      # the build. failBuildOnCVSS=8 fails only on a real CVSS >= 8 (the report is
+      # written first, so the uploads below still run).
       - name: Run OWASP Dependency-Check
+        env:
+          OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+          OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
         run: >-
           ./mvnw --batch-mode --no-transfer-progress -DskipTests verify
           org.owasp:dependency-check-maven:12.2.2:aggregate
           -Dformat=SARIF
           -DprettyPrint=true
           -DfailBuildOnCVSS=8
-          -DossindexAnalyzerEnabled=false
+          -DossIndexAnalyzerEnabled=true
+          -DossIndexUsername=$OSSINDEX_USERNAME
+          -DossIndexPassword=$OSSINDEX_TOKEN
+          -DossIndexWarnOnlyOnRemoteErrors=true
           -DsuppressionFiles=owasp-suppressions.xml
           -DdataDirectory=$HOME/.dependency-check-data
           -DautoUpdate=false


### PR DESCRIPTION
Supersedes #45 (which disabled OSS Index) — closing that one.

## What

Enable the Sonatype OSS Index analyzer in the OWASP scan, authenticated with a token.

`.github/workflows/dependency-scan.yml` (owasp scan step):
- `-DossIndexAnalyzerEnabled=true` (was `-DossindexAnalyzerEnabled=false`, lowercase — which never took effect anyway; see #45)
- `-DossIndexUsername` / `-DossIndexPassword` fed from new secrets `OSSINDEX_USERNAME` / `OSSINDEX_TOKEN` via `env`
- `-DossIndexWarnOnlyOnRemoteErrors=true` so a Sonatype outage / rate-limit only warns, never fails the build

Property names verified against dependency-check-maven 12.2.2 source (`@Parameter(property = "ossIndexAnalyzerEnabled" | "ossIndexUsername" | "ossIndexPassword" | "ossIndexWarnOnlyOnRemoteErrors")`).

## Required before this helps (repo settings)

1. Create a Sonatype OSS Index account (ossindex.sonatype.org) and generate an API token.
2. Add **Actions** secrets: `OSSINDEX_USERNAME` (account email), `OSSINDEX_TOKEN` (API token).
3. Optional — add the same two as **Dependabot** secrets so OSS Index also runs on Dependabot PRs (they don't get regular Actions secrets).

## Caveats

- On Dependabot PRs without step 3, OSS Index secrets are empty → that analyzer is skipped (the "missing credentials" warning returns, harmless); NVD still scans.
- OSS Index adds remote per-dependency queries → slightly slower scans; `WarnOnlyOnRemoteErrors` keeps that non-fatal.

## Verification

After secrets are set + merge: `OWASP Dependency-Check` run shows OSS Index querying ossindex.sonatype.org (no "disabled due to missing credentials"), token masked as `***` in logs, scan green, SARIF uploaded.